### PR TITLE
add let to common variable in LaTeXtoUnicode.vim

### DIFF
--- a/autoload/LaTeXtoUnicode.vim
+++ b/autoload/LaTeXtoUnicode.vim
@@ -214,7 +214,7 @@ function! s:L2U_longest_common_prefix(partmatches)
   for i in range(1, len(a:partmatches)-1)
     let p = a:partmatches[i]
     if len(p) < len(common)
-      common = common[0 : len(p)-1]
+      let common = common[0 : len(p)-1]
     endif
     for j in range(1, len(common)-1)
       if p[j] != common[j]


### PR DESCRIPTION
Fix bug "julia-vim/autoload/LaTeXtoUnicode.vim:217:7: Error: Unknown ex command 'common'  "
from vim-lint.