### PR TITLE
LaTeXtoUnicode#Refresh got to be called only on entering julia buffers.

### DIFF
--- a/ftdetect/julia.vim
+++ b/ftdetect/julia.vim
@@ -7,9 +7,9 @@ endif
 
 autocmd BufRead,BufNewFile *.jl      set filetype=julia
 
-autocmd BufEnter *                   call LaTeXtoUnicode#Refresh()
-autocmd FileType *                   call LaTeXtoUnicode#Refresh()
+autocmd BufEnter *.jl                   call LaTeXtoUnicode#Refresh()
+autocmd FileType *.jl                   call LaTeXtoUnicode#Refresh()
 
 " This autocommand is used to postpone the first initialization of LaTeXtoUnicode as much as possible,
 " by calling LaTeXtoUnicode#SetTab amd LaTeXtoUnicode#SetAutoSub only at VimEnter or later
-autocmd VimEnter *                   let g:l2u_did_vim_enter = 1 | call LaTeXtoUnicode#Init(0)
+autocmd VimEnter *.jl                   let g:l2u_did_vim_enter = 1 | call LaTeXtoUnicode#Init(0)


### PR DESCRIPTION
## Problem
`LaTextoUnicode#Refresh` is called whenever entering a buffer and the following error is raised.

```
Error detected while processing FileType Auto commands for "*":
E117: Unknown function: LaTeXtoUnicode#Refresh
Error detected while processing BufEnter Auto commands for "*":
E117: Unknown function: LaTeXtoUnicode#Refresh
Error detected while processing VimEnter Auto commands for "*":
E117: Unknown function: LaTeXtoUnicode#Init
```

## How To Reproduce
Install neobundle(https://github.com/Shougo/neobundle.vim) and add the following settings to your .vimrc:

```vim
 " Note: Skip initialization for vim-tiny or vim-small.
 if !1 | finish | endif

 if has('vim_starting')
   if &compatible
     set nocompatible               " Be iMproved
   endif

   " Required:
   set runtimepath+=~/.vim/bundle/neobundle.vim/
 endif

 " Required:
 call neobundle#begin(expand('~/.vim/bundle/'))

 " Let NeoBundle manage NeoBundle
 " Required:
 NeoBundleFetch 'Shougo/neobundle.vim'

 " My Bundles here:
 " Refer to |:NeoBundle-examples|.
 " Note: You don't set neobundle setting in .gvimrc!

 call neobundle#end()

 " Required:
 filetype plugin indent on

 " If there are uninstalled bundles found on startup,
 " this will conveniently prompt you to install them.
 NeoBundleCheck

NeoBundleLazy 'JuliaLang/julia-vim', {
            \ 'autoload': {"filetypes": ['julia'] }
            \ }
```

Open `sample.jl` with vim.

## Changes
Replaces glob patterns of BufEnter, FileType and VimEnter with *.jl to call LaTeXtoUnicode#Refresh only in julia buffers.