### PR TITLE
Optionally mark 0.3 deprecated types as errors

### DIFF
--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -11,8 +11,10 @@ endif
 
 scriptencoding utf-8
 
-if !exists("g:julialang_version")
-    let g:julialang_version = "0.3"
+if !exists("g:julia_version") || g:julia_version == "release"
+    let g:julia_version = "0.3"
+elseif g:julia_version == "development"
+    let g:julia_version = "0.4"
 end
 
 syntax cluster juliaExpressions		contains=@juliaParItems,@juliaStringItems,@juliaKeywordItems,@juliaBlocksItems,@juliaTypesItems,@juliaConstItems,@juliaMacroItems,@juliaOperatorItems,@juliaNumberItems,@juliaQuotedItems,@juliaCommentItems,@juliaErrorItems
@@ -226,8 +228,8 @@ hi def link juliaBuiltinTypeSpecial	Type
 hi def link juliaBuiltinTypeRandom	Type
 hi def link juliaBuiltinTypeDisplay	Type
 hi def link juliaBuiltinTypeOther	Type
-if g:julialang_version >= "0.4"
-    hi def link julia03DeprecatedTypes	juliaError
+if g:julia_version >= "0.4"
+    hi def link julia03DeprecatedTypes	juliaDeprecated
 else
     hi def link julia03DeprecatedTypes	Type
 end
@@ -312,6 +314,8 @@ hi def link juliaErrorSemicol		juliaError
 hi def link juliaErrorPrintfFmt		juliaError
 
 hi def link juliaError			Error
+
+hi def link juliaDeprecated		Todo
 
 syntax sync fromstart
 

--- a/syntax/julia.vim
+++ b/syntax/julia.vim
@@ -11,13 +11,17 @@ endif
 
 scriptencoding utf-8
 
+if !exists("g:julialang_version")
+    let g:julialang_version = "0.3"
+end
+
 syntax cluster juliaExpressions		contains=@juliaParItems,@juliaStringItems,@juliaKeywordItems,@juliaBlocksItems,@juliaTypesItems,@juliaConstItems,@juliaMacroItems,@juliaOperatorItems,@juliaNumberItems,@juliaQuotedItems,@juliaCommentItems,@juliaErrorItems
 syntax cluster juliaExprsPrintf		contains=@juliaExpressions,@juliaPrintfItems
 
 syntax cluster juliaParItems		contains=juliaParBlock,juliaSqBraBlock,juliaCurBraBlock
 syntax cluster juliaKeywordItems	contains=juliaKeyword,juliaRepKeyword,juliaTypedef
 syntax cluster juliaBlocksItems		contains=juliaConditionalBlock,juliaRepeatBlock,juliaBeginBlock,juliaFunctionBlock,juliaMacroBlock,juliaQuoteBlock,juliaTypeBlock,juliaImmutableBlock,juliaExceptionBlock,juliaLetBlock,juliaDoBlock,juliaModuleBlock
-syntax cluster juliaTypesItems		contains=juliaBuiltinTypeBasic,juliaBuiltinTypeNum,juliaBuiltinTypeC,juliaBuiltinTypeError,juliaBuiltinTypeIter,juliaBuiltinTypeString,juliaBuiltinTypeArray,juliaBuiltinTypeDict,juliaBuiltinTypeSet,juliaBuiltinTypeIO,juliaBuiltinTypeProcess,juliaBuiltinTypeRange,juliaBuiltinTypeRegex,juliaBuiltinTypeFact,juliaBuitinTypeFact,juliaBuiltinTypeSpecial,juliaBuiltinTypeRandom,juliaBuiltinTypeDisplay,juliaBuiltinTypeOther
+syntax cluster juliaTypesItems		contains=juliaBuiltinTypeBasic,juliaBuiltinTypeNum,juliaBuiltinTypeC,juliaBuiltinTypeError,juliaBuiltinTypeIter,juliaBuiltinTypeString,juliaBuiltinTypeArray,juliaBuiltinTypeDict,juliaBuiltinTypeSet,juliaBuiltinTypeIO,juliaBuiltinTypeProcess,juliaBuiltinTypeRange,juliaBuiltinTypeRegex,juliaBuiltinTypeFact,juliaBuitinTypeFact,juliaBuiltinTypeSpecial,juliaBuiltinTypeRandom,juliaBuiltinTypeDisplay,juliaBuiltinTypeOther,julia03DeprecatedTypes
 syntax cluster juliaConstItems		contains=juliaConstNum,juliaConstBool,juliaConstEnv,juliaConstIO,juliaConstMMap,juliaConstC,juliaConstGeneric
 syntax cluster juliaMacroItems		contains=juliaMacro,juliaDollarVar,juliaPrintfMacro
 syntax cluster juliaNumberItems		contains=juliaNumbers
@@ -64,16 +68,16 @@ syntax match   juliaTypedef		"\<\%(abstract\|typealias\|bitstype\)\>"
 
 syntax match   juliaComprehensionFor    contained "\<for\>"
 
-syntax match   juliaBuiltinTypeBasic	display "\<\%(Tuple\|NTuple\|Symbol\|\%(Intrinsic\)\?Function\|Union\|Type\%(Name\|Constructor\|Var\)\?\|Any\|ANY\|Vararg\|Top\|None\|Nothing\|Ptr\|Void\|Exception\|Module\|Box\|Expr\|LambdaStaticData\|\%(Data\|Union\)Type\|\%(LineNumber\|Label\|Goto\|Quote\|Top\|Symbol\|Getfield\)Node\|WeakRef\|Associative\|Method\(Table\)\?\)\>"
-syntax match   juliaBuiltinTypeNum	display "\<\%(Uint\%(\|8\|16\|32\|64\|128\)\|Int\%(eger\|8\|16\|32\|64\|128\)\?\|Float\%(ingPoint\|16\|32\|64\)\|Complex\%(32\|64\|128\)\?\|Bool\|Char\|Number\|Signed\|Unsigned\|Real\|Rational\|BigInt\|BigFloat\|MathConst\)\>"
+syntax match   juliaBuiltinTypeBasic	display "\<\%(Tuple\|NTuple\|Symbol\|\%(Intrinsic\)\?Function\|Union\|Type\%(Name\|Constructor\|Var\)\?\|Any\|ANY\|Vararg\|Top\|Ptr\|Void\|Exception\|Module\|Box\|Expr\|LambdaStaticData\|DataType\|\%(LineNumber\|Label\|Goto\|Quote\|Top\|Symbol\|Getfield\)Node\|WeakRef\|Associative\|Method\(Table\)\?\)\>"
+syntax match   juliaBuiltinTypeNum	display "\<\%(UInt\%(\|8\|16\|32\|64\|128\)\|Int\%(eger\|8\|16\|32\|64\|128\)\?\|AbstractFloat\|Float\%(16\|32\|64\)\|Complex\%(32\|64\|128\)\?\|Bool\|Char\|Number\|Signed\|Unsigned\|Real\|Rational\|BigInt\|BigFloat\|Irrational\)\>"
 syntax match   juliaBuiltinTypeC	display "\<\%(FileOffset\|C\%(u\?\%(char\|short\|int\|long\(long\)\?\)\|float\|double\|\%(ptrdiff\|s\?size\|wchar\|off\)_t\)\)\>"
-syntax match   juliaBuiltinTypeError	display "\<\%(\%(Bounds\|Divide\|Domain\|Memory\|\%(Stack\)\?Overflow\|EOF\|Undef\%(Ref\|Var\)\|System\|Type\|Parse\|Argument\|Key\|Load\|Method\|Inexact\)Error\|\%(Interrupt\|Error\|ProcessExited\)Exception\|DimensionMismatch\)\>"
+syntax match   juliaBuiltinTypeError	display "\<\%(\%(Bounds\|Divide\|Domain\|OutOfMemory\|\%(Stack\)\?Overflow\|EOF\|Undef\%(Ref\|Var\)\|System\|Type\|Parse\|Argument\|Key\|Load\|Method\|Inexact\)Error\|\%(Interrupt\|Error\|ProcessExited\)Exception\|DimensionMismatch\)\>"
 syntax match   juliaBuiltinTypeIter	display "\<\%(EachLine\|Enumerate\|Zip\|Filter\)\>"
-syntax match   juliaBuiltinTypeString	display "\<\%(DirectIndex\|ASCII\|UTF\%(8\|16\|32\)\|Byte\|Sub\|Rep\|Rev\|Rope\|W\)\?String\>"
+syntax match   juliaBuiltinTypeString	display "\<\%(Abstract\|DirectIndex\|ASCII\|UTF\%(8\|16\|32\)\|Byte\|Sub\|Rep\|Rev\|Rope\|W\)String\>"
 syntax match   juliaBuiltinTypeArray	display "\<\%(D\?Array\|\%(Abstract\|Dense\|Strided\)\?\%(Array\|Matrix\|Vec\%(tor\|OrMat\)\)\|SparseMatrixCSC\|Sub\%(Array\|\%(Or\)\?DArray\)\|\%(AbstractSparse\|Bit\|Shared\)\%(Array\|Vector\|Matrix\)\|\%\(D\|Bid\|\%(Sym\)\?Trid\)iagonal\|Woodbury\|Triangular\|Hermitian\|Symmetric\|UniformScaling\)\>"
 syntax match   juliaBuiltinTypeDict	display "\<\%(WeakKey\|ObjectId\)\?Dict\>"
 syntax match   juliaBuiltinTypeSet	display "\<\%(Int\)\?Set\>"
-syntax match   juliaBuiltinTypeIO	display "\<\%(IO\%(Stream\|Buffer\)\?\|CFILE\|Base64Pipe\|RawFD\|StatStruct\|DevNull\|FileMonitor\|PollingFileWatcher\|Timer\|UdpSocket\)\>"
+syntax match   juliaBuiltinTypeIO	display "\<\%(IO\%(Stream\|Buffer\)\?\|CFILE\|Base64EncodePipe\|RawFD\|StatStruct\|DevNull\|FileMonitor\|PollingFileWatcher\|Timer\|UDPSocket\)\>"
 syntax match   juliaBuiltinTypeProcess	display "\<\%(ProcessGroup\|PipeBuffer\|Cmd\)\>"
 syntax match   juliaBuiltinTypeRange	display "\<\%(Dims\|Range\%(Index\)\?\|\(Ordinal\|Step\|Unit\|Float\)Range\|Colon\)\>"
 syntax match   juliaBuiltinTypeRegex	display "\<Regex\%(Match\)\?\>"
@@ -84,6 +88,8 @@ syntax match   juliaBuiltinTypeSpecial	display "\<\%(LocalProcess\|ClusterManage
 syntax match   juliaBuiltinTypeRandom	display "\<\%(AbstractRNG\|MersenneTwister\)\>"
 syntax match   juliaBuiltinTypeDisplay	display "\<\%(\%(Text\)\?Display\|MIME\)\>"
 syntax match   juliaBuiltinTypeOther	display "\<\%(RemoteRef\|Task\|Condition\|VersionNumber\|TmStruct\|IPv[46]\)\>"
+
+syntax match   julia03DeprecatedTypes	display "\<\%(UdpSocket\|Nothing\|None\|String\|Uint\|Uint8\|Uint16\|Uint32\|Uint64\|Uint128\|Base64Pipe\|MemoryError\|UnionType\|MathConst\|FloatingPoint\)\>"
 
 syntax match   juliaConstNum		display "\<\%(NaN\%(16\|32\)\?\|Inf\%(16\|32\)\?\|eu\?\|pi\|π\|eulergamma\|γ\|catalan\|φ\|golden\)\>"
 syntax match   juliaConstBool		display "\<\%(true\|false\)\>"
@@ -220,6 +226,11 @@ hi def link juliaBuiltinTypeSpecial	Type
 hi def link juliaBuiltinTypeRandom	Type
 hi def link juliaBuiltinTypeDisplay	Type
 hi def link juliaBuiltinTypeOther	Type
+if g:julialang_version >= "0.4"
+    hi def link julia03DeprecatedTypes	juliaError
+else
+    hi def link julia03DeprecatedTypes	Type
+end
 hi def link juliaConstNum		Constant
 hi def link juliaConstEnv		Constant
 hi def link juliaConstIO		Constant


### PR DESCRIPTION
Add variable g:julialang_version, defaulted to 0.3.  If set to 0.4, types which were deprecated in 0.4 are syntax highlighted using juliaError.  Set up this way, the user has the option to opt into highlighting of newer versions, with the default highlighting reflecting the currently released 0.3 (soon to be 0.4).

This is slightly more comprehensive go at fixing the UInt* highlighting issue, which has been gently irritating me for some time (see #43).

If the behaviour here is desired, I can add a note to the docs.